### PR TITLE
Support multiple servers in preference order

### DIFF
--- a/lib/Foswiki/Contrib/LdapContrib.pm
+++ b/lib/Foswiki/Contrib/LdapContrib.pm
@@ -351,15 +351,29 @@ sub connect {
   $host ||= $this->{host};
   $port ||= $this->{port};
 
-  $this->{ldap} = Net::LDAP->new(
-    $host,
-    port => $port,
-    version => $this->{version},
-    inet4 => ($this->{ipv6}?0:1),
-    inet6 => ($this->{ipv6}?1:0),
-    timeout => 5, # TODO: make configurable
-  );
-
+  if ( $host =~ /,/) {
+    # This server preference list relies on the behaviour of Net::LDAP
+    # ldap://, ldaps:// URIs or host:port pairs are valid
+    my @hosts = split (/,/, $host);
+    $this->{ldap} = Net::LDAP->new(
+      \@hosts,
+      port => $port,
+      version => $this->{version},
+      inet4 => ($this->{ipv6}?0:1),
+      inet6 => ($this->{ipv6}?1:0),
+      timeout => 5, # TODO: make configurable
+    );
+  } else {
+    $this->{ldap} = Net::LDAP->new(
+      $host,
+      port => $port,
+      version => $this->{version},
+      inet4 => ($this->{ipv6}?0:1),
+      inet6 => ($this->{ipv6}?1:0),
+      timeout => 5, # TODO: make configurable
+    );
+  }
+  
   unless ($this->{ldap}) {
     $this->{error} = "failed to connect to $this->{host}";
     $this->{error} .= ": $@" if $@;


### PR DESCRIPTION
This relies on the the Net::LDAP behaviour of handling multiple server names. 
"HOST may also be a reference to an array of hosts, host-port pairs or URIs to try. Each will be tried in order until a connection is made. Only when all have failed will the result of undef be returned".

A future enhancement would be to do the server iteration ourselves and cache the most recent successful server.